### PR TITLE
Make random seeds deterministic in debug builds

### DIFF
--- a/builtins.c
+++ b/builtins.c
@@ -4555,8 +4555,13 @@ static void uuid_gen(uuid *u)
 	static uint64_t s_last = 0, s_cnt = 0;
 	static uint64_t g_seed = 0;
 
+#ifdef NDEBUG
 	if (!g_seed)
 		g_seed = (uint64_t)time(0) & MASK_FINAL;
+#else
+	if (!g_seed)
+		g_seed = 0xdeadbeefULL & MASK_FINAL;
+#endif
 
 	uint64_t now = get_time_in_usec();
 	compare_and_zero(now, &s_last, &s_cnt);

--- a/parse.c
+++ b/parse.c
@@ -3426,7 +3426,13 @@ prolog *pl_create()
 	if (!g_tpl_lib)
 		g_tpl_lib = "library";
 
+#ifdef NDEBUG
 	srandom(time(0)+clock()+getpid());
+#else
+	static unsigned seed = 0xdeadbeef;
+	srandom(++seed);
+#endif
+
 	prolog *pl = calloc(1, sizeof(prolog));
 	if (!pl) {
 		if (!--g_tpl_count)

--- a/skiplist.c
+++ b/skiplist.c
@@ -59,7 +59,12 @@ skiplist *sl_create(int (*compkey)(const void*, const void*))
 			free(l);
 			return NULL;
 		}
+#ifdef NDEBUG
 		l->seed = (unsigned)(size_t)(l + clock());
+#else
+		static unsigned seed = 0xdeadbeef;
+		l->seed = ++seed;
+#endif
 		l->level = 1;
 
 		for (int i = 0; i < MAX_LEVELS; i++)


### PR DESCRIPTION
This ensures that programs run bit by bit the same way when testing things repeatly.
(actually I would prefer if random seeding left as option to the user to be called from prolog)

Just a small patch, no followups planned here.