### PR TITLE
Errorhandling

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -150,6 +150,7 @@ static idx_t add_to_pool(const char *name)
 	size_t len = strlen(name);
 
 	if ((offset+len+1+1) >= g_pool_size) {
+		FAULTINJECT(return ERR_IDX);
 		size_t nbytes = g_pool_size * 2;
 		char *tmp = realloc(g_pool, nbytes);
 		if (!tmp) return ERR_IDX;
@@ -431,6 +432,7 @@ static rule *get_rule(module *m)
 
 static rule *create_rule(module *m, cell *c)
 {
+	FAULTINJECT(return NULL);
 	rule *h = get_rule(m);
 	h->val_off = c->val_off;
 	h->arity = c->arity;
@@ -870,6 +872,7 @@ static cell *make_cell(parser *p)
 
 parser *create_parser(module *m)
 {
+	FAULTINJECT(return NULL);
 	parser *p = calloc(1, sizeof(parser));
 	if (p)
 	{
@@ -916,6 +919,7 @@ query *create_query(module *m, int is_task)
 {
 	static uint64_t g_query_id = 0;
 
+	FAULTINJECT(return NULL);
 	query *q = calloc(1, sizeof(query));
 	if (q)
 	{
@@ -2787,6 +2791,7 @@ static bool parser_run(parser *p, const char *src, int dump)
 module *module_load_text(module *m, const char *src)
 {
 	parser *p = create_parser(m);
+	ensure(p);
 	p->consulting = true;
 	p->srcptr = (char*)src;
 	parser_tokenize(p, 0, 0);
@@ -2822,6 +2827,7 @@ module *module_load_text(module *m, const char *src)
 bool module_load_fp(module *m, FILE *fp)
 {
 	parser *p = create_parser(m);
+	ensure(p);
 	p->consulting = true;
 	p->fp = fp;
 	bool ok;
@@ -2970,6 +2976,7 @@ static void make_rule(module *m, const char *src)
 
 module *create_module(const char *name)
 {
+	FAULTINJECT(return NULL);
 	module *m = calloc(1, sizeof(module));
 	if (m)
 	{
@@ -3335,6 +3342,7 @@ bool pl_consult(prolog *pl, const char *filename)
 
 void* g_init(void)
 {
+	FAULTINJECT(return NULL);
 	g_pool = calloc(g_pool_size=INITIAL_POOL_SIZE, 1);
 	if (g_pool)	{
 		g_pool_offset = 0;
@@ -3410,6 +3418,7 @@ void g_destroy()
 
 prolog *pl_create()
 {
+	FAULTINJECT(return NULL);
 	++g_tpl_count;
 	if (g_tpl_count == 1 && g_init() == NULL)
 		return NULL;
@@ -3455,7 +3464,7 @@ prolog *pl_create()
 			!strcmp(lib->name, "lists")) {
 			size_t len = lib->end-lib->start;
 			char *src = malloc(len+1);
-                        ensure(src);
+			ensure(src);
 			memcpy(src, lib->start, len);
 			src[len] = '\0';
 			module_load_text(pl->m, src);

--- a/runtime.c
+++ b/runtime.c
@@ -48,24 +48,46 @@ uint64_t get_time_in_usec(void)
 }
 #endif
 
+
+static idx_t alloc_grow(void** addr, size_t elem_size, idx_t min_elements, idx_t max_elements)
+{
+	assert(min_elements <= max_elements);
+	idx_t elements = max_elements;
+	void* mem;
+
+	do {
+		mem = realloc(*addr, elem_size * elements);
+		if (mem) break;
+		elements = min_elements + (elements-min_elements)/2;
+		message("memory pressure reduce %u to %u", max_elements, elements);
+	} while (elements != min_elements);
+
+	if (!mem)
+		return 0;
+
+	*addr = mem;
+	return elements;
+}
+
+
 static void check_trail(query *q)
 {
 	if (q->st.tp > q->max_trails) {
 		q->max_trails = q->st.tp;
 
 		if (q->st.tp >= q->trails_size) {
-			q->trails_size += q->trails_size / 2;
 			FAULTINJECT(throw_error(q, q->st.curr_cell, "resource_error", "out_of_trail_space");
 				    q->error = true; return);
 
-			if ((sizeof(trail)*q->trails_size) > (1024LL*1024*1024)) {
+			idx_t new_trailssize = alloc_grow((void**)&q->trails, sizeof(trail), q->st.tp + 2, q->trails_size*2);
+			if (!new_trailssize)
+			{
 				throw_error(q, q->st.curr_cell, "resource_error", "out_of_trail_space");
 				q->error = true;
 				return;
 			}
 
-			q->trails = realloc(q->trails, sizeof(trail)*q->trails_size);
-			ensure(q->trails);
+			q->trails_size = new_trailssize;
 		}
 	}
 }
@@ -76,18 +98,18 @@ static void check_choice(query *q)
 		q->max_choices = q->cp;
 
 		if (q->cp >= q->choices_size) {
-			q->choices_size += q->choices_size / 2;
 			FAULTINJECT(throw_error(q, q->st.curr_cell, "resource_error", "out_of_choice_space");
 				    q->error = true; return);
 
-			if ((sizeof(choice)*q->choices_size) > (1024LL*1024*1024)) {
+			idx_t new_choicessize = alloc_grow((void**)&q->choices, sizeof(choice), q->cp + 2, q->choices_size*2);
+			if (!new_choicessize)
+			{
 				throw_error(q, q->st.curr_cell, "resource_error", "out_of_choice_space");
 				q->error = true;
 				return;
 			}
 
-			q->choices = realloc(q->choices, sizeof(choice)*q->choices_size);
-			ensure(q->choices);
+			q->choices_size = new_choicessize;
 		}
 	}
 }
@@ -98,24 +120,23 @@ static void check_frame(query *q)
 		q->max_frames = q->st.fp;
 
 		if (q->st.fp >= q->frames_size) {
-			idx_t save_frame = q->frames_size;
-			q->frames_size += q->frames_size / 2;
 			FAULTINJECT(throw_error(q, q->st.curr_cell, "resource_error", "out_of_frame_space");
 				    q->error = true; return);
 
-			if ((sizeof(frame)*q->frames_size) > (1024LL*1024*1024)) {
+			idx_t new_framessize = alloc_grow((void**)&q->frames, sizeof(frame), q->st.fp + 2, q->frames_size*2);
+			if (!new_framessize)
+			{
 				throw_error(q, q->st.curr_cell, "resource_error", "out_of_frame_space");
 				q->error = true;
 				return;
 			}
 
-			assert(q->frames_size);
-			q->frames = realloc(q->frames, sizeof(frame)*q->frames_size);
-			ensure(q->frames);
-			memset(q->frames+save_frame, 0, sizeof(frame)*(q->frames_size-save_frame));
+			memset(q->frames+q->frames_size, 0, sizeof(frame)*(new_framessize-q->frames_size));
+			q->frames_size = new_framessize;
 		}
 	}
 }
+
 
 static void check_slot(query *q, unsigned cnt)
 {
@@ -125,21 +146,23 @@ static void check_slot(query *q, unsigned cnt)
 		q->max_slots = q->st.sp;
 
 		while (nbr >= q->slots_size) {
-			idx_t save_slots = q->slots_size;
-			q->slots_size += q->slots_size / 2;
+			FAULTINJECT(throw_error(q, q->st.curr_cell, "resource_error", "out_of_slot_space");
+				    q->error = true; return);
 
-			if ((sizeof(slot)*q->slots_size) > (1024LL*1024*1024*2)) {
+			idx_t new_slotssize = alloc_grow((void**)&q->slots, sizeof(slot), nbr + 2, q->slots_size*2>nbr+2?q->slots_size*2:nbr+2);
+			if (!new_slotssize)
+			{
 				throw_error(q, q->st.curr_cell, "resource_error", "out_of_slot_space");
 				q->error = true;
 				return;
 			}
 
-			q->slots = realloc(q->slots, sizeof(slot)*q->slots_size);
-			ensure(q->slots);
-			memset(q->slots+save_slots, 0, sizeof(slot)*(q->slots_size-save_slots));
+			memset(q->slots+q->slots_size, 0, sizeof(slot)*(new_slotssize-q->slots_size));
+			q->slots_size = new_slotssize;
 		}
 	}
 }
+
 
 static void trace_call(query *q, cell *c, box_t box)
 {

--- a/runtime.c
+++ b/runtime.c
@@ -55,6 +55,8 @@ static void check_trail(query *q)
 
 		if (q->st.tp >= q->trails_size) {
 			q->trails_size += q->trails_size / 2;
+			FAULTINJECT(throw_error(q, q->st.curr_cell, "resource_error", "out_of_trail_space");
+				    q->error = true; return);
 
 			if ((sizeof(trail)*q->trails_size) > (1024LL*1024*1024)) {
 				throw_error(q, q->st.curr_cell, "resource_error", "out_of_trail_space");
@@ -75,6 +77,8 @@ static void check_choice(query *q)
 
 		if (q->cp >= q->choices_size) {
 			q->choices_size += q->choices_size / 2;
+			FAULTINJECT(throw_error(q, q->st.curr_cell, "resource_error", "out_of_choice_space");
+				    q->error = true; return);
 
 			if ((sizeof(choice)*q->choices_size) > (1024LL*1024*1024)) {
 				throw_error(q, q->st.curr_cell, "resource_error", "out_of_choice_space");
@@ -96,6 +100,8 @@ static void check_frame(query *q)
 		if (q->st.fp >= q->frames_size) {
 			idx_t save_frame = q->frames_size;
 			q->frames_size += q->frames_size / 2;
+			FAULTINJECT(throw_error(q, q->st.curr_cell, "resource_error", "out_of_frame_space");
+				    q->error = true; return);
 
 			if ((sizeof(frame)*q->frames_size) > (1024LL*1024*1024)) {
 				throw_error(q, q->st.curr_cell, "resource_error", "out_of_frame_space");

--- a/skiplist.c
+++ b/skiplist.c
@@ -41,10 +41,18 @@ struct skiplist_ {
 
 #define MAX_LEVELS 32
 #define MAX_LEVEL (MAX_LEVELS - 1)
-#define new_node_of_level(x) (slnode_t*)malloc(sizeof(slnode_t) + ((x) * sizeof(slnode_t*)))
+
+inline static slnode_t*
+new_node_of_level(unsigned x)
+{
+	FAULTINJECT(return NULL);
+	return malloc(sizeof(slnode_t) + ((x) * sizeof(slnode_t*)));
+}
+
 
 skiplist *sl_create(int (*compkey)(const void*, const void*))
 {
+	FAULTINJECT(return NULL);
 	skiplist *l = (skiplist*)calloc(1, sizeof(struct skiplist_));
 	if (l)
 	{

--- a/tpl.c
+++ b/tpl.c
@@ -157,6 +157,7 @@ int main(int ac, char *av[])
 	int version = 0, quiet = 0, daemon = 0;
 	int ns = 0;
 	void *pl = pl_create();
+	ensure(pl);
 	set_opt(pl, 1);
 
 	for (i = 1; i < ac; i++) {


### PR DESCRIPTION
Besides adding some FAULTINJECT's and more ensure()'s, now the real fun starts.

The second commit adds a new allocation strategy for trail, choice, frame and slot growing (and possibly more in future). This removes some limitations and makes error handling (failing allocations) nicer.

Note:
The memory allocation strategy relies on realloc() really failing and returning NULL, which is only true when the process is limited by ulimits or cgroups (Linux here). Otherwise the out-of-memory reaper will kill it.

Future directions: under memory pressure or when the memory footprint is dramatically shrunken some strategy for freeing and reclaiming unused memory could be implemented.

See this in action:
```
$  ulimit -S -v 8000000; ./tpl -g "time(hanoiq(27)),halt" samples/hanoi.pl
runtime.c:62 alloc_grow: memory pressure reduce 524288000 to 393216001
runtime.c:62 alloc_grow: memory pressure reduce 524288000 to 327680001
Time elapsed 93.2 secs
```
