### PR TITLE
faultinject.sh: make --continue work again (with --input)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ tpl: $(OBJECTS)
 	$(CC) -o tpl $(OBJECTS) $(OPT) $(LDFLAGS)
 
 profile:
-	$(MAKE) 'OPT=$(OPT) -O0 -pg -DDEBUG -DFAULTINJECT_VAR=g_faultinject'
+	$(MAKE) 'OPT=$(OPT) -O0 -pg -DDEBUG -DFAULTINJECT_NAME=g_faultinject'
 
 debug:
-	$(MAKE) 'OPT=$(OPT) -O0 -g -DDEBUG -DFAULTINJECT_VAR=g_faultinject'
+	$(MAKE) 'OPT=$(OPT) -O0 -g -DDEBUG -DFAULTINJECT_NAME=g_faultinject'
 
 test:
 	./tests/run.sh

--- a/cdebug.h
+++ b/cdebug.h
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <errno.h>
 
 #ifdef NDEBUG
@@ -14,12 +15,32 @@
 #endif
 #define ensure(cond, ...) do { if (!(cond)) {message( #cond " failed " __VA_ARGS__); abort();}} while (0)
 
-#if !defined(NDEBUG) && defined(FAULTINJECT_VAR)
-extern uint64_t FAULTINJECT_VAR;
+#if !defined(NDEBUG) && defined(FAULTINJECT_NAME)
+typedef struct {
+	uint64_t counter;
+	bool abort;
+} faultinject_t;
+extern faultinject_t FAULTINJECT_NAME;
 #define FAULTINJECT_ENABLED
-#define FAULTINJECT(...) do {if (!--FAULTINJECT_VAR){ message("injecting fault: " #__VA_ARGS__); __VA_ARGS__; }} while (0)
-#define FAULTINJECT_WHEN(cond, ...) do {if ((cond) &&!--FAULTINJECT_VAR){ __VA_ARGS__; }} while (0)
-#define FAULTINJECT_ONCE(cond,...) do {static bool tried = false; if (!tried && (cond)) { tried = true; FAULTINJECT(__VA_ARGS__);}} while (0)
+#define FAULTINJECT(...) do {						\
+		if (!--FAULTINJECT_NAME.counter){			\
+			message("injecting fault: " #__VA_ARGS__);	\
+			ensure(!FAULTINJECT_NAME.abort,			\
+			       "aborting: " #__VA_ARGS__ );		\
+			__VA_ARGS__;					\
+		}} while (0)
+#define FAULTINJECT_WHEN(cond, ...) do {			\
+		if ((cond) &&!--FAULTINJECT_NAME.counter){	\
+			ensure(!FAULTINJECT_NAME.abort,		\
+			       "aborting: " #__VA_ARGS__ );	\
+			__VA_ARGS__;				\
+		}} while (0)
+#define FAULTINJECT_ONCE(cond,...) do {			\
+		static bool tried = false;		\
+		if (!tried && (cond)) {			\
+			tried = true;			\
+			FAULTINJECT(__VA_ARGS__);	\
+		}} while (0)
 #else
 #define FAULTINJECT(...)
 #define FAULTINJECT_WHEN(...)

--- a/runtime.c
+++ b/runtime.c
@@ -21,7 +21,7 @@
 int g_tpl_interrupt = 0;
 
 #ifdef FAULTINJECT_ENABLED
-uint64_t FAULTINJECT_VAR;
+faultinject_t FAULTINJECT_NAME;
 #endif
 
 typedef enum { CALL, EXIT, REDO, NEXT, FAIL } box_t;

--- a/tests/testlist.faultinject
+++ b/tests/testlist.faultinject
@@ -120,4 +120,4 @@ $TPL -g halt tests/issues/test094.pl
 $TPL -g halt tests/issues/test108.pl
 $TPL -g halt tests/issues/test116.pl
 $TPL -g halt samples/sudoku.pl
-$TPL -g bench_peirera,halt samples/broken/peirera.pl
+# this doesnt scale: $TPL -g bench_peirera,halt samples/broken/peirera.pl

--- a/tpl.c
+++ b/tpl.c
@@ -148,9 +148,10 @@ int main(int ac, char *av[])
 		homedir = ".";
 
 #ifdef FAULTINJECT_ENABLED
-	FAULTINJECT_VAR = strtoul(getenv("FAULTSTART")?getenv("FAULTSTART"):"0", NULL, 0);
+	FAULTINJECT_NAME.counter = strtoul(getenv("FAULTSTART")?getenv("FAULTSTART"):"0", NULL, 0);
+	FAULTINJECT_NAME.abort = getenv("FAULTABORT")?true:false;
 	static bool faultinject_is_off;
-	faultinject_is_off = !FAULTINJECT_VAR;
+	faultinject_is_off = !FAULTINJECT_NAME.counter;
 #endif
 
 	char histfile[1024];
@@ -252,7 +253,7 @@ int main(int ac, char *av[])
 			pl_destroy(pl);
 #ifdef FAULTINJECT_ENABLED
 			if (faultinject_is_off)
-				fprintf(stderr, "\nCDEBUG FAULT INJECTION MAX %llu\n", 0LLU-FAULTINJECT_VAR);
+				fprintf(stderr, "\nCDEBUG FAULT INJECTION MAX %llu\n", 0LLU-FAULTINJECT_NAME.counter);
 #endif
 			return 1;
 		}
@@ -261,7 +262,7 @@ int main(int ac, char *av[])
 			pl_destroy(pl);
 #ifdef FAULTINJECT_ENABLED
 			if (faultinject_is_off)
-				fprintf(stderr, "\nCDEBUG FAULT INJECTION MAX %llu\n", 0LLU-FAULTINJECT_VAR);
+				fprintf(stderr, "\nCDEBUG FAULT INJECTION MAX %llu\n", 0LLU-FAULTINJECT_NAME.counter);
 #endif
 			return 1;
 		}
@@ -326,7 +327,7 @@ int main(int ac, char *av[])
 
 #ifdef FAULTINJECT_ENABLED
 	if (faultinject_is_off)
-		fprintf(stderr, "\nCDEBUG FAULT INJECTION MAX %llu\n", 0LLU-FAULTINJECT_VAR);
+		fprintf(stderr, "\nCDEBUG FAULT INJECTION MAX %llu\n", 0LLU-FAULTINJECT_NAME.counter);
 #endif
 
 	return halt_code;


### PR DESCRIPTION
Just few small changes, but this concludes the work on faultinject.sh for now

     ./tests/faultinject.sh -c -g -s -i tests/testlist.faultinject 

will restart where it left off, saving a lot time while one works on fixing bugs.