### PR TITLE
Add standards compliance workflow for GitHub Actions

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,0 +1,51 @@
+name: Standards compliance
+
+on:
+  push:
+    branches:
+      - testing
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Trealla ProLog
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Compile Trealla ProLog
+        run: |
+          make clean && make
+          sudo ln -s "$PWD/tpl" /usr/local/bin/tpl
+          tpl -g halt
+      - name: Install Logtalk
+        uses: logtalk-actions/setup-logtalk@master
+        with:
+          logtalk-version: git
+          logtalk-tool-dependencies: false
+      - name: Install Allure
+        run: |
+          wget https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/2.13.8/allure-commandline-2.13.8.zip
+          unzip allure-commandline-2.13.8.zip
+          cd allure-2.13.8/bin
+          sudo ln -s "$PWD/allure" /usr/local/bin/allure
+          allure --version
+      - name: Define environment variable for the test results
+        run: echo "EXIT=0" >> $GITHUB_ENV
+      - name: Run the Prolog standards compliance test suite
+        run: |
+          cd "$LOGTALKUSER/tests/prolog"
+          logtalk_tester -p trealla -g "set_logtalk_flag(clean,off)" -t 120 -f xunit -s "$HOME/logtalk/tests/prolog/" -w || EXIT=$?
+          echo "EXIT=$EXIT" >> $GITHUB_ENV
+      - name: Create Allure report
+        run: |
+          cd "$LOGTALKUSER/tests/prolog"
+          logtalk_allure_report -- Backend='Trealla ProLog' Commit=$GITHUB_SHA
+          mv allure-report $GITHUB_WORKSPACE/
+      - name: Upload Allure report
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./allure-report
+      - name: Set workflow exit status after the test results
+        run: exit $EXIT


### PR DESCRIPTION
This pull request adds the [discussed](https://github.com/infradig/trealla/issues/153) `.github/workflows/compliance.yml` workflow, which will run automatically whenever the `testing` branch is synced with the `devel` branch. Typically:

```bash
$ git checkout devel
$ git pull
$ git checkout testing
$ git merge devel
$ git push
```

The first two steps will only be necessary, of course, if working from a machine that may not have the latests `devel` branch commits.