### PR TITLE
Fix log10/1 arithmetic function exceptions

### DIFF
--- a/arith.c
+++ b/arith.c
@@ -2021,14 +2021,26 @@ static USE_RESULT pl_state fn_log10_1(query *q)
 	GET_FIRST_ARG(p1_tmp,any);
 	cell p1 = calc(q, p1_tmp);
 
-	if (is_integer(&p1)) {
-		q->accum.val_flt = log10(p1.val_num);
-		q->accum.val_type = TYPE_FLOAT;
-	} else if (is_float(&p1)) {
-		q->accum.val_flt = log10(p1.val_flt);
-		q->accum.val_type = TYPE_FLOAT;
-	} else if (is_variable(&p1)) {
+	if (is_variable(&p1)) {
 		return throw_error(q, &p1, "instantiation_error", "not_sufficiently_instantiated");
+	} else 	if (is_integer(&p1)) {
+		if (p1.val_num == 0) {
+			return throw_error(q, &p1, "evaluation_error", "zero_divisor");
+		} else if (p1.val_num < 0) {
+			return throw_error(q, &p1, "evaluation_error", "undefined");
+		} else {
+			q->accum.val_flt = log10(p1.val_num);
+			q->accum.val_type = TYPE_FLOAT;
+		}
+	} else if (is_float(&p1)) {
+		if (p1.val_flt == 0.0) {
+			return throw_error(q, &p1, "evaluation_error", "zero_divisor");
+		} else if (p1.val_flt < 0.0) {
+			return throw_error(q, &p1, "evaluation_error", "undefined");
+		} else {
+			q->accum.val_flt = log10(p1.val_flt);
+			q->accum.val_type = TYPE_FLOAT;
+		}
 	} else {
 		return throw_error(q, &p1, "type_error", "evaluable");
 	}


### PR DESCRIPTION
We now get:

```text
% running tests from object tests
% file: /Users/pmoura/Documents/Logtalk/logtalk3/tests/prolog/functions/log10_1/tests.lgt
% 
!     lgt_log10_1_01: failure 
!       test assertion failed: false=~=false
!       in file /Users/pmoura/Documents/Logtalk/logtalk3/tests/prolog/functions/log10_1/tests.lgt between lines 31-35
!     lgt_log10_1_02: failure 
!       test assertion failed: false=~=e
!       in file /Users/pmoura/Documents/Logtalk/logtalk3/tests/prolog/functions/log10_1/tests.lgt between lines 35-37
!     lgt_log10_1_03: failure 
!       test assertion failed: false=~=false
!       in file /Users/pmoura/Documents/Logtalk/logtalk3/tests/prolog/functions/log10_1/tests.lgt between lines 37-40
% lgt_log10_1_04: success
% lgt_log10_1_05: success
% lgt_log10_1_06: success
% lgt_log10_1_07: success
% lgt_log10_1_08: success
% lgt_log10_1_09: success
% 
% 9 tests: 0 skipped, 6 passed, 3 failed
% completed tests from object tests
```

Previously, the two last tests failed.