### PR TITLE
Fix setup_call_cleanup/3 predicate exception for non callable setup goal

### DIFF
--- a/library/builtins.pl
+++ b/library/builtins.pl
@@ -73,6 +73,7 @@ call_cleanup(G, C) :-
 	setup_call_cleanup(true, G, C).
 
 setup_call_cleanup(S, G, C) :-
+	must_be(S, callable, setup_call_cleanup/3, _),
 	call((S, !)),
 	'$register_cleanup'((C -> ! ; true)),
 	catch(G, Err, (catch((\+ \+ C), _, true), throw(Err))),


### PR DESCRIPTION
Additional tests for this and other cases have been pushed to the Logtalk git repo. With the change in this pull requests, all the tests pass.